### PR TITLE
Created branch for PyQt5/libffi7 for Ubuntu 20.04/kubuntu 20.04 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <h4>Change Log</h4>
 
+* This branch is currently in testing status. It's purpose it to get ksdr working in the latest kubuntu (and Ubuntu) based linux, version 20.04 LTS. So far it is working in kubuntu 20.04 LTS (It should also work in Ubuntu 20.04 LTS but has not been tested yet). 
+* These changes were made AFTER I installed kerberossdr using the normal method and it didnt work in a new kubuntu 20.04 install, so that was my installation method, I just edited the python files afterwards...basically, the only changes needed were to import PyQt5 where ever PyQt4 was imported before (using slightly different syntax than PyQt4, you cant just change PyQt4 to PyQt5). The files that needed the PyQt5 import changes were: _GUI/hydra_main_window.py, _signalProcessing/hydra_signal_processor.py and in _GUI/hydra_main_window_layout.py. Then, find/replaced all the instances of .setMargin(0) to .setContentsMargins(0,0,0,0) in the _GUI/hydra_main_window_layout.py file.
+
 * Selecting “Uniform Gain” will allow you to set the same gain value for all four receivers.
 * The antenna spacing value (s, fraction of wavelength) is automatically calculated based on frequency and a user set antenna spacing (s’, meters). For circular arrays, just use the spacing between each antenna, the program will calculate the radius for you.
 * I’ve added a button to the Web UI to enable the sync display and the noise source in one click. If the noise source or the sync display (or both) is enabled the button will disable both. This should make calibration less cumbersome on mobile devices.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <h4>Change Log</h4>
 
-* This branch is currently in testing status. It's purpose it to get ksdr working in the latest kubuntu (and Ubuntu) based linux, version 20.04 LTS. So far it is working in kubuntu 20.04 LTS (It should also work in Ubuntu 20.04 LTS but has not been tested yet). 
-* These changes were made AFTER I installed kerberossdr using the normal method and it didnt work in a new kubuntu 20.04 install, so that was my installation method, I just edited the python files afterwards...basically, the only changes needed were to import PyQt5 where ever PyQt4 was imported before (using slightly different syntax than PyQt4, you cant just change PyQt4 to PyQt5). The files that needed the PyQt5 import changes were: _GUI/hydra_main_window.py, _signalProcessing/hydra_signal_processor.py and in _GUI/hydra_main_window_layout.py. Then, find/replaced all the instances of .setMargin(0) to .setContentsMargins(0,0,0,0) in the _GUI/hydra_main_window_layout.py file.
+* The purpose of this branch is to get ksdr working in the latest kubuntu (and Ubuntu) based linux, which use different libraries (PyQt5 and libffi7). This branch is currently in testing status, but I have successfully gotten it working in both Ubuntu 20.04 LTS and kubuntu 20.04 LTS. 
+* The installation instructions below have been updated for installing PyQt5 and libffi7, which are compatable with the new Linux releases instead of PyQt4 and libffi6. 
+* A little background in case you run into problems so you will know what I did to get this working (if you want to go to the original rtl-sdr blog github repository and make the changes manually). Basically, the only changes needed in the Python code were to import PyQt5 where ever PyQt4 was imported  (using slightly different syntax than PyQt4, you cant just change PyQt4 to PyQt5, see  _GUI/hydra_main_window.py for an example). The files that needed the PyQt5 import changes were: _GUI/hydra_main_window.py, _signalProcessing/hydra_signal_processor.py and in _GUI/hydra_main_window_layout.py. Then, find/replaced all the instances of .setMargin(0) to .setContentsMargins(0,0,0,0) in the _GUI/hydra_main_window_layout.py file. Finally, I updated the install instructions to get rid of Pyqt4 and use PyQt5, and then changed libffi6 to libffi7.
 
 * Selecting “Uniform Gain” will allow you to set the same gain value for all four receivers.
 * The antenna spacing value (s, fraction of wavelength) is automatically calculated based on frequency and a user set antenna spacing (s’, meters). For circular arrays, just use the spacing between each antenna, the program will calculate the radius for you.
@@ -20,7 +21,7 @@
 1. <h4>Install Dependencies via apt:</h4>
 
   `sudo apt update`<br>
-  `sudo apt install python3-pip python3-pyqt4 pyqt4-dev-tools build-essential gfortran libatlas3-base libatlas-base-dev python3-dev python3-setuptools libffi6 libffi-dev python3-tk pkg-config libfreetype6-dev php7.2-cli`
+  `sudo apt install python3-pip build-essential gfortran libatlas3-base libatlas-base-dev python3-dev python3-setuptools libffi-dev python3-tk pkg-config libfreetype6-dev php-cli wondershaper python3-pyqt5 libffi7`
 
 2. <h4>Uninstall any preinstalled numpy packages as we want to install with pip3 to get optimized BLAS.</h4>
 
@@ -67,7 +68,7 @@ Install KerberosSDR Demo Software
 
 7. <h4>Clone or unzip the software</h4>
 
-  `git clone https://github.com/rtlsdrblog/kerberossdr`<br>
+  `git clone https://github.com/rfjohnso/kerberossdr`<br>
   `cd kerberossdr`<br>
   `sh setup_init.sh`
 

--- a/_GUI/hydra_main_window.py
+++ b/_GUI/hydra_main_window.py
@@ -45,10 +45,10 @@ sys.path.insert(0, signalProcessorPath)
 
 from hydra_receiver import ReceiverRTLSDR
 
-# Import graphical user interface packages
-from PyQt4.QtGui import *
-from PyQt4 import QtCore
-from PyQt4 import QtGui
+# Import graphical user interface packages --Modified to use PyQt5
+from PyQt5 import QtGui, QtCore
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
 
 try:
     _fromUtf8 = QtCore.QString.fromUtf8

--- a/_GUI/hydra_main_window_layout.py
+++ b/_GUI/hydra_main_window_layout.py
@@ -24,7 +24,9 @@
 #
 # WARNING! All changes made in this file will be lost!
 
-from PyQt4 import QtCore, QtGui
+from PyQt5 import QtGui, QtCore
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
 
 try:
     _fromUtf8 = QtCore.QString.fromUtf8
@@ -56,7 +58,7 @@ class Ui_MainWindow(object):
         self.page_4 = QtGui.QWidget()
         self.page_4.setObjectName(_fromUtf8("page_4"))
         self.verticalLayout_7 = QtGui.QVBoxLayout(self.page_4)
-        self.verticalLayout_7.setMargin(0)
+        self.verticalLayout_7.setContentsMargins(0,0,0,0)
         self.verticalLayout_7.setObjectName(_fromUtf8("verticalLayout_7"))
         self.groupBox_7 = QtGui.QGroupBox(self.page_4)
         self.groupBox_7.setObjectName(_fromUtf8("groupBox_7"))
@@ -317,7 +319,7 @@ class Ui_MainWindow(object):
         self.page = QtGui.QWidget()
         self.page.setObjectName(_fromUtf8("page"))
         self.horizontalLayout_2 = QtGui.QHBoxLayout(self.page)
-        self.horizontalLayout_2.setMargin(0)
+        self.horizontalLayout_2.setContentsMargins(0,0,0,0)
         self.horizontalLayout_2.setObjectName(_fromUtf8("horizontalLayout_2"))
 
         self.groupBox = QtGui.QGroupBox(self.page)
@@ -379,7 +381,7 @@ class Ui_MainWindow(object):
         self.page_2 = QtGui.QWidget()
         self.page_2.setObjectName(_fromUtf8("page_2"))
         self.verticalLayout = QtGui.QVBoxLayout(self.page_2)
-        self.verticalLayout.setMargin(0)
+        self.verticalLayout.setContentsMargins(0,0,0,0)
         self.verticalLayout.setObjectName(_fromUtf8("verticalLayout"))
         self.groupBox_2 = QtGui.QGroupBox(self.page_2)
         self.groupBox_2.setObjectName(_fromUtf8("groupBox_2"))
@@ -489,7 +491,7 @@ class Ui_MainWindow(object):
         self.page_3 = QtGui.QWidget()
         self.page_3.setObjectName(_fromUtf8("page_3"))
         self.verticalLayout_3 = QtGui.QVBoxLayout(self.page_3)
-        self.verticalLayout_3.setMargin(0)
+        self.verticalLayout_3.setContentsMargins(0,0,0,0)
         self.verticalLayout_3.setObjectName(_fromUtf8("verticalLayout_3"))
         self.checkBox_en_passive_radar = QtGui.QCheckBox(self.page_3)
         self.checkBox_en_passive_radar.setObjectName(_fromUtf8("checkBox_en_passive_radar"))

--- a/_signalProcessing/hydra_signal_processor.py
+++ b/_signalProcessing/hydra_signal_processor.py
@@ -34,7 +34,9 @@ from scipy.signal import correlate
 #import matplotlib.pyplot as plt
 
 # GUI support
-from PyQt4 import QtGui, QtCore
+from PyQt5 import QtGui, QtCore
+from PyQt5.QtCore import *
+from PyQt5.QtGui import *
 
 # Import the pyArgus module
 #root_path = os.getcwd()


### PR DESCRIPTION
This branch uses PyQt5 and libffi7 in order to get the kerberossdr software to work in Ubuntu 20.04 and kubuntu 20.04.
I also updated the directions for installing with the PyQt5/libffi7 libraries.
I have tested the changes on both OS but only on one computer.
I dont know about backward compatiblity with older linux versions with PyQt5/libffi7, so I dont know if these changes can be straight up merged or not.
This is my first pull request and I am super new to python as well. so sorry if I did this pull request thing wrong or forgot anything in my repo but it seems to work for me.

